### PR TITLE
プロパティの呼び出し方が、使われる想定からして危なそうだったので修正

### DIFF
--- a/Assets/Scripts/Pages/CharacterColorChangePage/CharacterColorChangePageView.cs
+++ b/Assets/Scripts/Pages/CharacterColorChangePage/CharacterColorChangePageView.cs
@@ -36,7 +36,7 @@ public class CharacterColorChangePageView : PageViewBase
     public IObservable<Color> OnRightFootColorChanged { get; private set; }
     public IObservable<Color> OnLeftFootColorChanged { get; private set; }
 
-    private void Start()
+    private async void Start()
     {
         OnClickReturnButton = _returnButton.OnClickAsObservable();
         OnRightHandColorChanged = _rightHandColorChanged.AsObservable();

--- a/Assets/Scripts/Pages/CharacterColorChangePage/CharacterColorChangePageView.cs
+++ b/Assets/Scripts/Pages/CharacterColorChangePage/CharacterColorChangePageView.cs
@@ -28,17 +28,22 @@ public class CharacterColorChangePageView : PageViewBase
     private readonly Subject<Color> _leftFootColorChanged = new Subject<Color>();
 
     // イベント公開プロパティ
-    public IObservable<Unit> OnClickReturnButton => _returnButton.OnClickAsObservable();
+    public IObservable<Unit> OnClickReturnButton { get; private set; }
     //public IObservable<Unit> OnClickResetButton => _resetButton.OnClickAsObservable();
     
-    public IObservable<Color> OnRightHandColorChanged => _rightHandColorChanged.AsObservable();
-    public IObservable<Color> OnLeftHandColorChanged => _leftHandColorChanged.AsObservable();
-    public IObservable<Color> OnRightFootColorChanged => _rightFootColorChanged.AsObservable();
-    public IObservable<Color> OnLeftFootColorChanged => _leftFootColorChanged.AsObservable();
+    public IObservable<Color> OnRightHandColorChanged { get; private set; }
+    public IObservable<Color> OnLeftHandColorChanged { get; private set; }
+    public IObservable<Color> OnRightFootColorChanged { get; private set; }
+    public IObservable<Color> OnLeftFootColorChanged { get; private set; }
 
-    private async void Start()
+    private void Start()
     {
-        
+        OnClickReturnButton = _returnButton.OnClickAsObservable();
+        OnRightHandColorChanged = _rightHandColorChanged.AsObservable();
+        OnLeftHandColorChanged = _leftHandColorChanged.AsObservable();
+        OnRightFootColorChanged = _rightFootColorChanged.AsObservable();
+        OnLeftFootColorChanged = _leftFootColorChanged.AsObservable();
+
         itemSetTabGroup.OnTabLoaded
             .Subscribe(x =>
             {

--- a/Assets/Scripts/Pages/FirstPage/FirstPageView.cs
+++ b/Assets/Scripts/Pages/FirstPage/FirstPageView.cs
@@ -15,10 +15,18 @@ public class FirstPageView : PageViewBase
     [SerializeField] private Button _colorPageButton;
 
     [SerializeField] private Text _settingsValueText;
-    public IObservable<Unit> OnClickPage => _nextPageButton.OnClickAsObservable();
-    public IObservable<Unit> OnClickModal => _nextModalButton.OnClickAsObservable();
+    public IObservable<Unit> OnClickPage { get; private set; }
+    public IObservable<Unit> OnClickModal { get; private set; }
 
-    public IObservable<Unit> OnClickColorPage => _colorPageButton.OnClickAsObservable();
+    public IObservable<Unit> OnClickColorPage { get; private set; }
+
+    private void Start()
+    {
+        OnClickPage = _nextPageButton.OnClickAsObservable();
+        OnClickModal = _nextModalButton.OnClickAsObservable();
+        OnClickColorPage = _colorPageButton.OnClickAsObservable();
+    }
+
     public void SetView(FirstPageModel model)
     {
         _messageText.SetText(model.FirstPageMessage);

--- a/Assets/Scripts/Pages/NextPage/NextPageView.cs
+++ b/Assets/Scripts/Pages/NextPage/NextPageView.cs
@@ -1,10 +1,9 @@
-using System;
-using UnityEngine;
 using ScreenSystem.Page;
-using UnityEngine.UI;
-using UniRx;
+using System;
 using TMPro;
-using UnityEngine.Serialization;
+using UniRx;
+using UnityEngine;
+using UnityEngine.UI;
 
 public class NextPageView : PageViewBase
 {
@@ -13,8 +12,14 @@ public class NextPageView : PageViewBase
     [SerializeField] private Button _returnButton;
 
     [SerializeField] private Button _soundSettingButton;
-    public IObservable<Unit> OnClickSoundSettingButton => _soundSettingButton.OnClickAsObservable();
-    public IObservable<Unit> OnClickReturn => _returnButton.OnClickAsObservable();
+    public IObservable<Unit> OnClickSoundSettingButton { get; private set; }
+    public IObservable<Unit> OnClickReturn { get; private set; }
+
+    private void Start()
+    {
+        OnClickSoundSettingButton = _soundSettingButton.OnClickAsObservable();
+        OnClickReturn = _returnButton.OnClickAsObservable();
+    }
 
     public void SetGuid(int guid)
     {

--- a/Assets/Scripts/Pages/SoundSettingPage/SoundSettingPageView.cs
+++ b/Assets/Scripts/Pages/SoundSettingPage/SoundSettingPageView.cs
@@ -15,11 +15,11 @@ public class SoundSettingPageView : PageViewBase
     [SerializeField] private Slider _bgmVolumeSlider;
     [SerializeField] private Slider _voiceVolumeSlider;
 
-    public IObservable<Unit> OnClickReturnButton => _returnButton.OnClickAsObservable();
-    public IObservable<float> OnSeVolumeChanged => _seVolumeSlider.OnValueChangedAsObservable();
-    public IObservable<float> OnBgmVolumeChanged => _bgmVolumeSlider.OnValueChangedAsObservable();
-    public IObservable<float> OnVoiceVolumeChanged => _voiceVolumeSlider.OnValueChangedAsObservable();
-    
+    public IObservable<Unit> OnClickReturnButton { get; private set; }
+    public IObservable<float> OnSeVolumeChanged { get; private set; }
+    public IObservable<float> OnBgmVolumeChanged { get; private set; }
+    public IObservable<float> OnVoiceVolumeChanged { get; private set; }
+
     public void SetSeVolume(float seVolume)
     {
         _seVolumeSlider.value = seVolume;
@@ -34,9 +34,12 @@ public class SoundSettingPageView : PageViewBase
     {
         _voiceVolumeSlider.value = volume;
     }
-    // Update is called once per frame
-    void Update()
+
+    private void Start()
     {
-        
+        OnClickReturnButton = _returnButton.OnClickAsObservable();
+        OnSeVolumeChanged = _seVolumeSlider.OnValueChangedAsObservable();
+        OnBgmVolumeChanged = _bgmVolumeSlider.OnValueChangedAsObservable();
+        OnVoiceVolumeChanged = _voiceVolumeSlider.OnValueChangedAsObservable();
     }
 }


### PR DESCRIPTION
イベントのプロパティが `=>` で定義されていますが、これだと呼び出しごとに評価されるため、複数箇所からの呼び出しに対して不向きになっています。
あまりよいとは思えないので、あらかじめ評価しておくべきではないかと思い修正を提案します。